### PR TITLE
merged bias score into lambda

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,6 +9,7 @@ $ conda install -c conda-forge nltk <br />
 $ conda install -c conda-forge boto3<br />
 $ pip install vaderSentiment<br />
 $ python -m ipykernel install<br />
+$ pip install aws-xray-sdk<br /> 
 
 PS: Some of the packages below, such as vaderSentiment, were used in our tests but not implemented in our final code
 
@@ -18,11 +19,14 @@ $ python -m spacy download en_core_web_sm<br />
 $ python -m spacy download en_core_web_md<br />
 
 ###  `Environment Variables`
-Windows 10: added 3 directories in the PATH variable: D:\Anaconda3 ; D:\Anaconda3\Scripts ; D:\Anaconda3\Library\bin<br />
-Included on the TOP of the PATH variable:<br />
+* added 3 directories in the PATH variable:<br />
+D:\Anaconda3 ; D:\Anaconda3\Scripts ; D:\Anaconda3\Library\bin<br />
+* Included on the TOP of the PATH variable:<br />
 c:\Anaconda3\envs\sentim            =>> Python<br />
 c:\Anaconda3\envs\sentim\Scripts    =>> Pytest<br />
 c:\Anaconda3\Scripts                =>> Conda<br />
+* Created a new Env variable to disable AWS_XRAY locally:<br />
+AWS_XRAY_SDK_ENABLED = false<br />
 
 ###  `Pytest settings`
 Created PYTHONPATH environment variable pointing to the "src" directory for Pytest:<br />

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SentimentalistsApp-Backend
 
-## Folder Sctructure:
+## Folder Structure:
 
 The SENTIMENTALISTSAPP-BACKEND is divided into the following folders:
 

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -1,20 +1,21 @@
 # Back End Scope tasks
 
+## FIRST MVP
+
 **Python Libraries used for NLP processing**
 - Newspaper: Keywords, Summary, Title and Text
 - TextBlob: Sentiment Analysis (Polarity & Subjectivity Score)
 - Spacy (*): TAG Matcher method, returns a list of entities according to the TAG chosen (Person, Org, Gpe ...)
+             (ready only in the backend: spacyMatcher.py module)
 
 **URL Credibility**
 - Gate Source Credibility API: returns the SCORE, SOURCE and the CATEGORY (left, right, fake news, etc)
 
+
 **Future Ideas**
-* GATE Generic Opinion Mining API: sentiment analysis - polarity, score, sarcasm, etc
-* Compare documents
-* Search Feature
-* Upload a document / Type a document
-* Detect the Language of the text / Translate the text
-* Enable users to see effectively the sentiment analysis results when a simple sentence is typed in the screen.
+* Upload / Type a document instead of URL input.
+* GATE Generic Opinion Mining API: sentiment analysis / sarcasm in sentences.
+* Compare documents.
+* Search Feature.
 
-
-(*) Left to be implemented in a future MVP.
+(*) Spacy Frontend to be implemented in a future MVP.

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -40,7 +40,6 @@ def test_SentAnalPolarity():
     assert result_dict['results'][1] == result_score
 
 def test_SentAnalSubjectivity():
-    #result_score = {"type": "subjectivity",  'outcome': {"score": 1.0}}
     result_score = {"type": "objectivity",  'outcome': {"score": 0.0}}
     result_dict = lf.lambda_handler({"url":"http://sentimentalists-tests.s3-website.eu-west-2.amazonaws.com/today.html"}, "")
     assert result_dict['results'][2] == result_score
@@ -59,3 +58,13 @@ def test_ArticleKeywords():
     result_score = ['test', 'horrible', 'today', 'day', 'daytoday']
     result_dict = lf.lambda_handler({"url":"http://sentimentalists-tests.s3-website.eu-west-2.amazonaws.com/today.html"}, "")
     assert result_dict['article']['keywords'].sort() == result_score.sort()
+
+def test_BiasScore_withNO_credibility():
+    result_dict = lf.lambda_handler({"url":"http://sentimentalists-tests.s3-website.eu-west-2.amazonaws.com/today.html"}, "")
+    result_score = {'type': 'bias', 'outcome':{'score': 100.0}}
+    assert result_dict['results'][3] == result_score
+
+def test_BiasScore_with_credibility():
+    result_dict = lf.lambda_handler({"url":"https://www.bbc.co.uk/news/uk-54234084"}, "")
+    result_score = {'type': 'bias', 'outcome': {'score': 45.0}}
+    assert result_dict['results'][3] == result_score


### PR DESCRIPTION
The call to getBiasScore was included into the lambda_function.py
@GCJyo just one comment,:
In your getBiasScore.py you always assume that there will be valid values for polarity and subjectivity, only credibility can be inexistent. You should think of what to return in case there is only credibility available. I am assuming at the moment that they are always present but this can fail ...